### PR TITLE
Fix Bugs with RSS & Responsive Tag / Category Listing Pages

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,7 +14,8 @@ highlight_code = true
 # Whether to build a search index to be used later on by a JavaScript library
 build_search_index = false
 
-generate_rss = true
+generate_feed = true
+feed_filename = "rss.xml"
 
 taxonomies = [
            { name = "tags" },

--- a/sass/static/style.scss
+++ b/sass/static/style.scss
@@ -86,7 +86,7 @@ body {
             grid-template-columns: 1fr;
 
             > div {
-                grid-colum-start: 1;
+                grid-column-start: 1;
             }
         }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -5,9 +5,10 @@
         <title>{{ config.title }}</title>
         <link rel="stylesheet" href="/static/style.css">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        {% if config.generate_rss %}
-        <link type="application/rss+xml" rel="alternate" href="/rss.xml">
-        {% endif %}
+
+        {% block rss %}
+        <link rel="alternate" type="application/rss+xml" title="RSS" href="{{ get_url(path="rss.xml", trailing_slash=false) }}">
+        {% endblock %}
 
         <!-- OpenGraph Meta -->
         {% block opengraph %}{% endblock %}
@@ -20,8 +21,8 @@
                 <a href="/tags">tags</a>
                 <a href="{{ get_url(path="@/pages/about.md") }}">about</a>
 
-                {% if config.generate_rss %}
-                <a href="{{ get_url(path="rss.xml") }}">rss</a>
+                {% if config.generate_feed %}
+                <a href="{{ get_url(path="rss.xml", trailing_slash=false) }}">rss</a>
                 {% endif %}
             </div>
         </header>


### PR DESCRIPTION
RSS configuration and template logic changed in a new version of Zola. Update
the base.html and config.toml files accordingly.
Closes #14 

A typo in style.scss caused the listing pages for tags and categories to not
properly take up the whole width of the screen. Fixing the typo resolves this.
Closes #13 