### PR TITLE
Opt-out of FLoC tracking

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,8 @@ ZOLA_VERSION = "0.11.0"
 
 [context.deploy-preview]
 command = "zola build --base-url $DEPLOY_PRIME_URL"
+
+[[headers]]
+  for = "/*"
+  [headers.values]
+  Permissions-Policy = "interest-cohort=()"


### PR DESCRIPTION
Follow the documentation for
https://developer.chrome.com/blog/floc/#how-can-websites-opt-out-of-the-floc-computation
and https://docs.netlify.com/routing/headers/ to opt out of Google's Federated
Learning of Cohorts.

Closes #21